### PR TITLE
Protect debug prints

### DIFF
--- a/public/send_email_server.py
+++ b/public/send_email_server.py
@@ -14,8 +14,10 @@ SMTP_USER = os.environ.get('YANDEX_USER', 'bulmitya@yandex.ru')
 SMTP_PASSWORD = os.environ.get('YANDEX_PASSWORD', 'phkjbyabxtncllze')
 TO_EMAIL = 'bulanov.ds@infobm.ru'
 
-print(f"SMTP_USER: {SMTP_USER}")  # Для отладки, удалить в продакшн
-print(f"TO_EMAIL: {TO_EMAIL}")  # Для отладки, удалить в продакшн
+if app.debug:
+    # Выводим параметры только в режиме отладки
+    print(f"SMTP_USER: {SMTP_USER}")
+    print(f"TO_EMAIL: {TO_EMAIL}")
 
 @app.route('/send-claim-email', methods=['POST'])
 def send_claim_email():


### PR DESCRIPTION
## Summary
- only show SMTP config while Flask is in debug mode

## Testing
- `python3 -m py_compile public/send_email_server.py`


------
https://chatgpt.com/codex/tasks/task_e_688cb0d94180832d8db739354915e348