### PR TITLE
Add send_email and date utility tests

### DIFF
--- a/public/date_utils.js
+++ b/public/date_utils.js
@@ -1,0 +1,17 @@
+function toDDMMYYYY(input) {
+  if (!input) return '';
+  if (input.includes('/')) return input; // already formatted
+  const [year, month, day] = input.split('-');
+  if (!year || !month || !day) return input;
+  return `${day}/${month}/${year}`;
+}
+
+function toYYYYMMDD(input) {
+  if (!input) return '';
+  if (input.includes('-')) return input; // already formatted
+  const [day, month, year] = input.split('/');
+  if (!year || !month || !day) return input;
+  return `${year}-${month}-${day}`;
+}
+
+module.exports = { toDDMMYYYY, toYYYYMMDD };

--- a/tests/test_date_utils.js
+++ b/tests/test_date_utils.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+const { toDDMMYYYY, toYYYYMMDD } = require('../public/date_utils');
+
+assert.strictEqual(toDDMMYYYY('2020-12-31'), '31/12/2020');
+assert.strictEqual(toDDMMYYYY('31/12/2020'), '31/12/2020');
+assert.strictEqual(toDDMMYYYY(''), '');
+
+assert.strictEqual(toYYYYMMDD('31/12/2020'), '2020-12-31');
+assert.strictEqual(toYYYYMMDD('2020-12-31'), '2020-12-31');
+assert.strictEqual(toYYYYMMDD(''), '');
+
+console.log('date_utils tests passed');

--- a/tests/test_send_email.py
+++ b/tests/test_send_email.py
@@ -1,0 +1,55 @@
+import types
+import sys
+from unittest.mock import MagicMock
+
+# Create minimal flask stub
+flask_stub = types.ModuleType('flask')
+class Flask:
+    def __init__(self, name):
+        self.name = name
+    def route(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+    def run(self, *args, **kwargs):
+        pass
+flask_stub.Flask = Flask
+flask_stub.request = types.SimpleNamespace(json=None)
+flask_stub.jsonify = lambda obj: obj
+sys.modules['flask'] = flask_stub
+
+# Stub for flask_cors
+flask_cors_stub = types.ModuleType('flask_cors')
+flask_cors_stub.CORS = lambda app: None
+sys.modules['flask_cors'] = flask_cors_stub
+
+import public.send_email_server as ses
+
+
+def test_send_claim_email_success(monkeypatch):
+    flask_stub.request.json = {
+        'contractor': 'Cont',
+        'contractNumber': '1',
+        'contractDate': '2021-01-01',
+        'amountRub': '10',
+        'amountForeign': '20',
+        'currency': 'USD',
+        'requirement': 'req',
+        'documentsLink': 'link'
+    }
+
+    mock_context = MagicMock()
+    mock_server = mock_context.__enter__.return_value
+    monkeypatch.setattr(ses.smtplib, 'SMTP_SSL', lambda *args, **kwargs: mock_context)
+
+    result = ses.send_claim_email()
+    assert result == {'success': True}
+    mock_server.login.assert_called_with(ses.SMTP_USER, ses.SMTP_PASSWORD)
+    mock_server.sendmail.assert_called_with(ses.SMTP_USER, ses.TO_EMAIL, mock_server.sendmail.call_args.args[2])
+
+
+def test_send_claim_email_no_data():
+    flask_stub.request.json = None
+    result, status = ses.send_claim_email()
+    assert status == 400
+    assert result == {'error': 'No data'}


### PR DESCRIPTION
## Summary
- add simple date utility module
- add pytest test for email sending using Flask stubs and mock SMTP
- add node-based tests for date utilities

## Testing
- `node tests/test_date_utils.js`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cb0da8ce8832db5d7d46c28e1f223